### PR TITLE
Implement MCQ web application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,79 @@
-# temp
+# MCQ 웹 도구
+
+이 애플리케이션은 다중 선택형 문항(MCQ)을 순차적으로 풀고, 진행 상황을 확인하며, 관리자 기능을 통해 응답을 관리할 수 있는 간단한 웹 서비스입니다.
+
+## 주요 기능
+
+- SQLite 기반 사용자/문항/응답 저장
+- 사용자/관리자 역할별 로그인
+- 문항별 응답 저장 및 진행 현황 표시
+- 관리자용 성적표, 문항 통계, CSV/JSON 내보내기
+- 관리자용 JSON 문항 데이터 로드
+
+## 로컬 실행
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+export ADMIN_USERNAME=admin
+export ADMIN_PASSWORD=adminpass
+export DEFAULT_USER_USERNAME=testuser
+export DEFAULT_USER_PASSWORD=testpass
+export DATASET_PATH=/path/to/questions.json  # 선택 사항
+python app.py
+```
+
+기본 포트는 `8080`이며 `PORT` 환경 변수를 통해 변경할 수 있습니다.
+
+## Docker 실행
+
+```bash
+docker build -t mcq-app .
+
+docker run -d -p 8080:8080 \
+  -v /path/to/data:/app/data \
+  -e DB_PATH=/app/data/app.db \
+  -e DATASET_PATH=/app/data/questions.json \
+  -e ADMIN_USERNAME=admin \
+  -e ADMIN_PASSWORD=adminpass \
+  -e DEFAULT_USER_USERNAME=testuser \
+  -e DEFAULT_USER_PASSWORD=testpass \
+  mcq-app
+```
+
+- `DB_PATH`는 SQLite 데이터베이스 파일 경로를 지정합니다.
+- `DATASET_PATH`가 지정되면 초기 실행 시 문항이 자동으로 로드됩니다.
+- `ADMIN_USERNAME`, `ADMIN_PASSWORD`는 최초 관리자 계정을 만듭니다.
+
+## 문항 JSON 형식
+
+```json
+[
+  {
+    "numbering_temp": 1,
+    "id": 1225,
+    "topic": "MONSTER",
+    "question": "개선 방안에 대한 설명으로 옳은 것은? (가) 중심 영역 (나) 가장자리 (다) 두 영역 공통",
+    "choices": [
+      "가, 나 만 옳음",
+      "가, 다 만 옳음",
+      "나, 다 만 옳음",
+      "가, 나, 다 모두 옳음",
+      "가, 나, 다 모두 옳지 않음"
+    ],
+    "answer": 3
+  }
+]
+```
+
+## 관리자 전용 기능
+
+- `/admin` 페이지에서 응답 결과와 문항 통계를 확인할 수 있습니다.
+- `/admin/load` 페이지에서 서버에 존재하는 JSON 파일 경로를 입력하면 문항을 교체할 수 있습니다. 이때 기존 응답은 삭제됩니다.
+- `/admin/export?format=csv` 또는 `format=json`으로 결과를 다운로드할 수 있습니다.
+
+## 비고
+
+- UI 텍스트는 모두 한국어로 제공됩니다.
+- 세션은 쿠키 기반 Flask 세션을 사용합니다.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,482 @@
+import json
+import os
+import sqlite3
+from datetime import datetime
+from functools import wraps
+
+from flask import (
+    Flask,
+    abort,
+    flash,
+    g,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+    Response,
+)
+from werkzeug.security import check_password_hash, generate_password_hash
+
+app = Flask(__name__)
+app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "dev-secret")
+DATABASE_PATH = os.environ.get("DB_PATH", "app.db")
+
+
+def get_db():
+    if "db" not in g:
+        conn = sqlite3.connect(DATABASE_PATH)
+        conn.row_factory = sqlite3.Row
+        g.db = conn
+    return g.db
+
+
+@app.teardown_appcontext
+def close_db(exception):
+    db = g.pop("db", None)
+    if db is not None:
+        db.close()
+
+
+def init_db():
+    db = get_db()
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT UNIQUE NOT NULL,
+            password_hash TEXT NOT NULL,
+            role TEXT NOT NULL CHECK(role IN ('user', 'admin'))
+        )
+        """
+    )
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS questions (
+            id INTEGER PRIMARY KEY,
+            numbering_temp INTEGER NOT NULL,
+            topic TEXT NOT NULL,
+            question TEXT NOT NULL,
+            choices TEXT NOT NULL,
+            answer INTEGER NOT NULL
+        )
+        """
+    )
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS responses (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            question_id INTEGER NOT NULL,
+            selected_choice INTEGER NOT NULL,
+            timestamp TEXT NOT NULL,
+            UNIQUE(user_id, question_id),
+            FOREIGN KEY(user_id) REFERENCES users(id),
+            FOREIGN KEY(question_id) REFERENCES questions(id)
+        )
+        """
+    )
+    db.commit()
+
+
+@app.before_request
+def before_request():
+    init_db()
+
+
+def create_default_admin():
+    username = os.environ.get("ADMIN_USERNAME")
+    password = os.environ.get("ADMIN_PASSWORD")
+    if not username or not password:
+        return
+    db = get_db()
+    cur = db.execute("SELECT id FROM users WHERE username = ?", (username,))
+    if cur.fetchone() is None:
+        db.execute(
+            "INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)",
+            (username, generate_password_hash(password), "admin"),
+        )
+        db.commit()
+
+
+create_default_admin()
+
+
+def create_default_user():
+    username = os.environ.get("DEFAULT_USER_USERNAME")
+    password = os.environ.get("DEFAULT_USER_PASSWORD")
+    if not username or not password:
+        return
+    db = get_db()
+    cur = db.execute("SELECT id FROM users WHERE username = ?", (username,))
+    if cur.fetchone() is None:
+        db.execute(
+            "INSERT INTO users (username, password_hash, role) VALUES (?, ?, 'user')",
+            (username, generate_password_hash(password)),
+        )
+        db.commit()
+
+
+create_default_user()
+
+
+def login_required(role=None):
+    def decorator(view):
+        @wraps(view)
+        def wrapped_view(**kwargs):
+            user_id = session.get("user_id")
+            if user_id is None:
+                return redirect(url_for("login"))
+            if role is not None and session.get("role") != role:
+                abort(403)
+            return view(**kwargs)
+
+        return wrapped_view
+
+    return decorator
+
+
+@app.route("/login", methods=["GET", "POST"])
+def login():
+    if request.method == "POST":
+        username = request.form.get("username", "").strip()
+        password = request.form.get("password", "")
+        db = get_db()
+        cur = db.execute(
+            "SELECT id, password_hash, role FROM users WHERE username = ?",
+            (username,),
+        )
+        user = cur.fetchone()
+        if user and check_password_hash(user["password_hash"], password):
+            session.clear()
+            session["user_id"] = user["id"]
+            session["username"] = username
+            session["role"] = user["role"]
+            if user["role"] == "admin":
+                return redirect(url_for("admin_dashboard"))
+            return redirect(url_for("question", numbering=1))
+        flash("로그인에 실패했습니다. 다시 확인하세요.")
+    return render_template("login.html")
+
+
+@app.route("/logout")
+def logout():
+    session.clear()
+    return redirect(url_for("login"))
+
+
+def get_question_by_number(numbering):
+    db = get_db()
+    cur = db.execute(
+        "SELECT * FROM questions WHERE numbering_temp = ? ORDER BY numbering_temp",
+        (numbering,),
+    )
+    return cur.fetchone()
+
+
+def get_questions():
+    db = get_db()
+    cur = db.execute("SELECT * FROM questions ORDER BY numbering_temp")
+    return cur.fetchall()
+
+
+@app.route("/")
+def index():
+    if session.get("role") == "admin":
+        return redirect(url_for("admin_dashboard"))
+    if session.get("user_id"):
+        return redirect(url_for("question", numbering=1))
+    return redirect(url_for("login"))
+
+
+@app.route("/questions/<int:numbering>", methods=["GET", "POST"])
+@login_required(role="user")
+def question(numbering):
+    q = get_question_by_number(numbering)
+    if q is None:
+        flash("해당 문항이 없습니다.")
+        return redirect(url_for("question", numbering=1))
+
+    db = get_db()
+    user_id = session["user_id"]
+    if request.method == "POST":
+        choice = request.form.get("choice")
+        if choice is not None:
+            timestamp = datetime.utcnow().isoformat()
+            db.execute(
+                "INSERT INTO responses (user_id, question_id, selected_choice, timestamp)"
+                " VALUES (?, ?, ?, ?)"
+                " ON CONFLICT(user_id, question_id) DO UPDATE SET selected_choice=excluded.selected_choice, timestamp=excluded.timestamp",
+                (user_id, q["id"], int(choice), timestamp),
+            )
+            db.commit()
+            flash("답안이 저장되었습니다.")
+        action = request.form.get("action")
+        next_number = numbering
+        if action == "next":
+            next_number = numbering + 1
+        elif action == "prev":
+            next_number = numbering - 1
+        elif action == "stay":
+            next_number = numbering
+
+        questions = get_questions()
+        numbers = [item["numbering_temp"] for item in questions]
+        if next_number not in numbers:
+            if action == "next" and numbers:
+                next_number = numbers[-1]
+            elif action == "prev" and numbers:
+                next_number = numbers[0]
+            else:
+                next_number = numbering
+        return redirect(url_for("question", numbering=next_number))
+
+    cur = db.execute(
+        "SELECT selected_choice FROM responses WHERE user_id = ? AND question_id = ?",
+        (user_id, q["id"]),
+    )
+    existing = cur.fetchone()
+    selected_choice = existing["selected_choice"] if existing else None
+
+    questions = get_questions()
+    progress = []
+    for item in questions:
+        cur = db.execute(
+            "SELECT 1 FROM responses WHERE user_id = ? AND question_id = ?",
+            (user_id, item["id"]),
+        )
+        progress.append(
+            {
+                "number": item["numbering_temp"],
+                "answered": cur.fetchone() is not None,
+            }
+        )
+
+    choices = json.loads(q["choices"])
+    return render_template(
+        "question.html",
+        question=q,
+        choices=choices,
+        selected_choice=selected_choice,
+        progress=progress,
+    )
+
+
+@app.route("/admin")
+@login_required(role="admin")
+def admin_dashboard():
+    db = get_db()
+    questions = get_questions()
+    users = db.execute("SELECT id, username FROM users WHERE role = 'user'").fetchall()
+
+    results = []
+    for user in users:
+        for q in questions:
+            response = db.execute(
+                "SELECT selected_choice, timestamp FROM responses WHERE user_id = ? AND question_id = ?",
+                (user["id"], q["id"]),
+            ).fetchone()
+            selected = response["selected_choice"] if response else None
+            timestamp = response["timestamp"] if response else None
+            correct = None
+            if selected is not None:
+                correct = int(selected) == int(q["answer"])
+            results.append(
+                {
+                    "user": user["username"],
+                    "question_number": q["numbering_temp"],
+                    "question_id": q["id"],
+                    "topic": q["topic"],
+                    "question": q["question"],
+                    "selected": selected,
+                    "answer": q["answer"],
+                    "correct": correct,
+                    "timestamp": timestamp,
+                }
+            )
+
+    per_question = []
+    for q in questions:
+        answered = db.execute(
+            "SELECT COUNT(*) FROM responses WHERE question_id = ?",
+            (q["id"],),
+        ).fetchone()[0]
+        correct_count = db.execute(
+            "SELECT COUNT(*) FROM responses WHERE question_id = ? AND selected_choice = ?",
+            (q["id"], q["answer"]),
+        ).fetchone()[0]
+        accuracy = (correct_count / answered * 100) if answered else None
+        per_question.append(
+            {
+                "question_number": q["numbering_temp"],
+                "answered": answered,
+                "correct": correct_count,
+                "accuracy": accuracy,
+            }
+        )
+
+    return render_template(
+        "admin_dashboard.html",
+        results=results,
+        per_question=per_question,
+    )
+
+
+def validate_dataset(data):
+    if not isinstance(data, list):
+        return False
+    required_keys = {"numbering_temp", "id", "topic", "question", "choices", "answer"}
+    for item in data:
+        if not isinstance(item, dict):
+            return False
+        if not required_keys.issubset(item.keys()):
+            return False
+        if not isinstance(item["choices"], list):
+            return False
+        if not isinstance(item["answer"], int):
+            return False
+    return True
+
+
+@app.route("/admin/load", methods=["GET", "POST"])
+@login_required(role="admin")
+def load_dataset():
+    if request.method == "POST":
+        path = request.form.get("path", "").strip()
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            flash("파일을 읽을 수 없거나 형식이 잘못되었습니다.")
+            return render_template("load_dataset.html")
+        if not validate_dataset(data):
+            flash("데이터 구조가 올바르지 않습니다.")
+            return render_template("load_dataset.html")
+
+        db = get_db()
+        db.execute("DELETE FROM responses")
+        db.execute("DELETE FROM questions")
+        for item in data:
+            db.execute(
+                "INSERT INTO questions (id, numbering_temp, topic, question, choices, answer)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    item["id"],
+                    item["numbering_temp"],
+                    item["topic"],
+                    item["question"],
+                    json.dumps(item["choices"], ensure_ascii=False),
+                    item["answer"],
+                ),
+            )
+        db.commit()
+        flash("문제가 성공적으로 로드되었습니다.")
+        return redirect(url_for("admin_dashboard"))
+    return render_template("load_dataset.html")
+
+
+@app.route("/admin/export")
+@login_required(role="admin")
+def export_results():
+    export_format = request.args.get("format", "csv")
+    db = get_db()
+    query = db.execute(
+        """
+        SELECT q.id AS question_id, q.topic, q.question, r.user_id, u.username,
+               r.selected_choice, q.answer,
+               CASE WHEN r.selected_choice = q.answer THEN 1 ELSE 0 END AS correct,
+               r.timestamp
+        FROM responses r
+        JOIN questions q ON r.question_id = q.id
+        JOIN users u ON r.user_id = u.id
+        ORDER BY r.timestamp
+        """
+    ).fetchall()
+
+    rows = [dict(row) for row in query]
+    if export_format == "json":
+        data = json.dumps(rows, ensure_ascii=False)
+        return Response(
+            data,
+            mimetype="application/json",
+            headers={"Content-Disposition": "attachment; filename=results.json"},
+        )
+
+    # CSV export
+    import csv
+    from io import StringIO
+
+    output = StringIO()
+    writer = csv.writer(output)
+    writer.writerow(
+        [
+            "question_id",
+            "topic",
+            "question",
+            "user_id",
+            "username",
+            "selected_choice",
+            "correct_answer",
+            "is_correct",
+            "timestamp",
+        ]
+    )
+    for row in rows:
+        writer.writerow(
+            [
+                row["question_id"],
+                row["topic"],
+                row["question"],
+                row["user_id"],
+                row["username"],
+                row["selected_choice"],
+                row["answer"],
+                row["correct"],
+                row["timestamp"],
+            ]
+        )
+    csv_data = output.getvalue()
+    return Response(
+        csv_data,
+        mimetype="text/csv",
+        headers={"Content-Disposition": "attachment; filename=results.csv"},
+    )
+
+
+def load_initial_dataset():
+    dataset_path = os.environ.get("DATASET_PATH")
+    if not dataset_path:
+        return
+    db = get_db()
+    cur = db.execute("SELECT COUNT(*) FROM questions")
+    if cur.fetchone()[0] > 0:
+        return
+    try:
+        with open(dataset_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return
+    if not validate_dataset(data):
+        return
+    for item in data:
+        db.execute(
+            "INSERT INTO questions (id, numbering_temp, topic, question, choices, answer)"
+            " VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                item["id"],
+                item["numbering_temp"],
+                item["topic"],
+                item["question"],
+                json.dumps(item["choices"], ensure_ascii=False),
+                item["answer"],
+            ),
+        )
+    db.commit()
+
+
+load_initial_dataset()
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 8080))
+    app.run(host="0.0.0.0", port=port)

--- a/data/sample_questions.json
+++ b/data/sample_questions.json
@@ -1,0 +1,18 @@
+[
+  {
+    "numbering_temp": 1,
+    "id": 100,
+    "topic": "예시",
+    "question": "다음 중 예시 정답은 무엇입니까?",
+    "choices": ["선택지 1", "선택지 2", "선택지 3", "선택지 4"],
+    "answer": 2
+  },
+  {
+    "numbering_temp": 2,
+    "id": 101,
+    "topic": "예시",
+    "question": "두 번째 문항입니다.",
+    "choices": ["가", "나", "다", "라"],
+    "answer": 1
+  }
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask==3.0.2
+werkzeug==3.0.1

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -1,0 +1,72 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>관리자 대시보드</h1>
+<p><a href="{{ url_for('export_results', format='csv') }}">CSV 내보내기</a> | <a href="{{ url_for('export_results', format='json') }}">JSON 내보내기</a></p>
+<h2>응시자별 결과</h2>
+<table>
+    <thead>
+        <tr>
+            <th>사용자</th>
+            <th>문항 번호</th>
+            <th>문항 ID</th>
+            <th>주제</th>
+            <th>문항</th>
+            <th>응답</th>
+            <th>정답</th>
+            <th>정오 여부</th>
+            <th>제출 시각</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for row in results %}
+            <tr>
+                <td>{{ row['user'] }}</td>
+                <td>{{ row['question_number'] }}</td>
+                <td>{{ row['question_id'] }}</td>
+                <td>{{ row['topic'] }}</td>
+                <td>{{ row['question'] }}</td>
+                <td>{{ row['selected'] if row['selected'] is not none else '-' }}</td>
+                <td>{{ row['answer'] }}</td>
+                <td>
+                    {% if row['correct'] is none %}
+                        미응답
+                    {% elif row['correct'] %}
+                        정답
+                    {% else %}
+                        오답
+                    {% endif %}
+                </td>
+                <td>{{ row['timestamp'] or '-' }}</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+<h2>문항별 통계</h2>
+<table>
+    <thead>
+        <tr>
+            <th>문항 번호</th>
+            <th>응답 수</th>
+            <th>정답 수</th>
+            <th>정답률 (%)</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for item in per_question %}
+            <tr>
+                <td>{{ item['question_number'] }}</td>
+                <td>{{ item['answered'] }}</td>
+                <td>{{ item['correct'] }}</td>
+                <td>
+                    {% if item['accuracy'] is none %}
+                        -
+                    {% else %}
+                        {{ '%.1f'|format(item['accuracy']) }}
+                    {% endif %}
+                </td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ title or '문항 시스템' }}</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            margin: 0;
+            padding: 0;
+            background: #f5f5f5;
+        }
+        header {
+            background: #1f2937;
+            color: white;
+            padding: 12px 20px;
+        }
+        main {
+            padding: 20px;
+        }
+        .container {
+            max-width: 960px;
+            margin: 0 auto;
+            background: white;
+            padding: 20px;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+        }
+        .actions {
+            margin-top: 16px;
+        }
+        .alert {
+            background: #fee2e2;
+            color: #991b1b;
+            padding: 10px;
+            margin-bottom: 10px;
+        }
+        nav a {
+            color: white;
+            margin-right: 12px;
+            text-decoration: none;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        th, td {
+            border: 1px solid #d1d5db;
+            padding: 8px;
+            text-align: left;
+        }
+        th {
+            background: #f3f4f6;
+        }
+        .flex {
+            display: flex;
+            gap: 20px;
+        }
+        .progress-panel {
+            width: 200px;
+            border-left: 1px solid #d1d5db;
+            padding-left: 20px;
+        }
+        .progress-item {
+            display: flex;
+            justify-content: space-between;
+            padding: 4px 0;
+        }
+        .btn {
+            padding: 8px 12px;
+            background: #2563eb;
+            color: white;
+            border: none;
+            cursor: pointer;
+        }
+        .btn-secondary {
+            background: #6b7280;
+        }
+        form {
+            margin: 0;
+        }
+        .text-right {
+            text-align: right;
+        }
+        .link-button {
+            background: none;
+            border: none;
+            color: #2563eb;
+            cursor: pointer;
+            padding: 0;
+        }
+    </style>
+</head>
+<body>
+<header>
+    <div>
+        <strong>문항 풀이 시스템</strong>
+        {% if session.get('username') %}
+            <span style="margin-left: 12px;">{{ session['username'] }} ({{ '관리자' if session['role'] == 'admin' else '응시자' }})</span>
+            <a href="{{ url_for('logout') }}">로그아웃</a>
+            {% if session['role'] == 'admin' %}
+                <a href="{{ url_for('admin_dashboard') }}">관리자 대시보드</a>
+                <a href="{{ url_for('load_dataset') }}">문항 데이터 로드</a>
+            {% endif %}
+        {% endif %}
+    </div>
+</header>
+<main>
+    <div class="container">
+        {% with messages = get_flashed_messages() %}
+            {% if messages %}
+                {% for message in messages %}
+                    <div class="alert">{{ message }}</div>
+                {% endfor %}
+            {% endif %}
+        {% endwith %}
+        {% block content %}{% endblock %}
+    </div>
+</main>
+</body>
+</html>

--- a/templates/load_dataset.html
+++ b/templates/load_dataset.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>문항 데이터 로드</h1>
+<form method="post">
+    <label for="path">서버 내 JSON 파일 경로</label><br>
+    <input type="text" id="path" name="path" style="width: 100%;" required>
+    <div class="actions">
+        <button class="btn" type="submit">로드</button>
+    </div>
+</form>
+<p>새로운 파일을 로드하면 기존 응답이 삭제됩니다.</p>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>로그인</h1>
+<form method="post">
+    <div>
+        <label for="username">사용자 이름</label><br>
+        <input type="text" id="username" name="username" required>
+    </div>
+    <div style="margin-top: 12px;">
+        <label for="password">비밀번호</label><br>
+        <input type="password" id="password" name="password" required>
+    </div>
+    <div class="actions">
+        <button class="btn" type="submit">로그인</button>
+    </div>
+</form>
+{% endblock %}

--- a/templates/question.html
+++ b/templates/question.html
@@ -1,0 +1,39 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>문항 {{ question['numbering_temp'] }}</h1>
+<div class="flex">
+    <div style="flex: 1;">
+        <p><strong>문항 ID:</strong> {{ question['id'] }}</p>
+        <p><strong>주제:</strong> {{ question['topic'] }}</p>
+        <p>{{ question['question'] }}</p>
+        <form method="post">
+            <div>
+                {% for choice in choices %}
+                    <div style="margin-bottom: 8px;">
+                        <label>
+                            <input type="radio" name="choice" value="{{ loop.index }}" {% if selected_choice == loop.index %}checked{% endif %}>
+                            {{ loop.index }}. {{ choice }}
+                        </label>
+                    </div>
+                {% endfor %}
+            </div>
+            <div class="actions">
+                <button class="btn" type="submit" name="action" value="stay">저장</button>
+                <button class="btn" type="submit" name="action" value="prev">이전</button>
+                <button class="btn" type="submit" name="action" value="next">다음</button>
+            </div>
+        </form>
+    </div>
+    <div class="progress-panel">
+        <h3>진행 현황</h3>
+        {% for item in progress %}
+            <div class="progress-item">
+                <form method="get" action="{{ url_for('question', numbering=item['number']) }}">
+                    <button class="link-button" type="submit">{{ item['number'] }}</button>
+                </form>
+                <span>{{ '완료' if item['answered'] else '미응답' }}</span>
+            </div>
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement a Flask-based MCQ solving service with SQLite persistence, role-based login, per-user sessions, and admin analytics/export features
- add Korean-language templates with sequential navigation, progress tracking, dataset loader, and sample JSON questions
- document setup, environment variables, and Docker usage for running the service

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_b_68db597d62688331a05828b99107c651